### PR TITLE
Add github workflow to produce docker image

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,19 @@
+FROM nimlang/nim:1.0.4 AS builder
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    make \
+    cmake \
+    autoconf \
+    automake \
+    libtool \
+    curl
+RUN cd Mineros && \
+    nimble install https://github.com/MerosCrypto/mc_randomx && \
+    nimble install https://github.com/MerosCrypto/mc_bls && \
+    nimble install https://github.com/MerosCrypto/Nim-Meros-RPC && \
+    nim c src/main.nim
+
+FROM ubuntu:devel
+COPY --from=builder ./Mineros/build/Mineros .
+ENTRYPOINT ["./Mineros"]

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get update && apt-get install -y \
     automake \
     libtool \
     curl
-RUN cd Mineros && \
-    nimble install https://github.com/MerosCrypto/mc_randomx && \
+RUN nimble install https://github.com/MerosCrypto/mc_randomx && \
     nimble install https://github.com/MerosCrypto/mc_bls && \
-    nimble install https://github.com/MerosCrypto/Nim-Meros-RPC && \
-    nim c src/main.nim
+    nimble install https://github.com/MerosCrypto/Nim-Meros-RPC
+COPY . ./
+RUN nim c src/main.nim
 
 FROM ubuntu:devel
-COPY --from=builder ./Mineros/build/Mineros .
+COPY --from=builder ./build/Mineros .
 ENTRYPOINT ["./Mineros"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: build
+
+on: push
+
+jobs:
+    mineros:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Prepare Dockerfile
+                run: cp ./.github/workflows/Dockerfile .
+            -   name: Docker Build
+                run: docker build -t meroscrypto/mineros:latest
+            -   name: Docker Login
+                if: github.ref == 'refs/heads/master'
+                uses: azure/docker-login@v1
+                with:
+                    username: merosmaintainers
+                    password: ${{ secrets.DOCKER_PASSWORD }}
+            -   name: Docker Publish
+                if: github.ref == 'refs/heads/master'
+                run: docker push meroscrypto/mineros:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,16 +1,20 @@
 name: build
 
-on: push
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
 
 jobs:
     mineros:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
-            -   name: Prepare Dockerfile
-                run: cp ./.github/workflows/Dockerfile .
             -   name: Docker Build
-                run: docker build -t meroscrypto/mineros:latest
+                run: docker build -f .github/workflows/Dockerfile -t meroscrypto/mineros:latest .
             -   name: Docker Login
                 if: github.ref == 'refs/heads/master'
                 uses: azure/docker-login@v1


### PR DESCRIPTION
This PR provides CI/CD capabilities that deliver a docker image to `meroscrypto/mineros:latest`.

Additional steps:
- Requires that secret `DOCKER_PASSWORD` be configured in the repo settings.